### PR TITLE
Don't go to cosine similarity mode when words are added or removed

### DIFF
--- a/wordembeddingdemo.js
+++ b/wordembeddingdemo.js
@@ -591,7 +591,6 @@ class Demo {
         let addedWords = [];
         let removedWords = [];
         let absentWords = [];
-        let finalWordsToAdd = new Set(); // handle duplicate additions for word selection / display at the end of this function
         // split user input across periods, spaces, commas or semicolons
         const words = document.getElementById("modify-word-input").value
                               .split(/[ ;,.]+/); 
@@ -609,13 +608,11 @@ class Demo {
             if (this.scatterWords.includes(word)) {  // remove word
                 this.scatterWords = this.scatterWords.filter(item => item !== word);
                 removedWords.push(word);
-                if (finalWordsToAdd.has(word)) finalWordsToAdd.delete(word);
                 wordModified = true;
             } else { // add word if in vocab
                 if (this.vocab.has(word)) {
                     this.scatterWords.push(word);
                     addedWords.push(word);
-                    finalWordsToAdd.add(word);
                     wordModified = true;
                 } else { // word not found
                     absentWords.push(word);
@@ -624,18 +621,21 @@ class Demo {
             }
         });
 
-        // make first added word active
-        // if no words have been added, deactivate any currently active word
-        if (finalWordsToAdd.size > 0){
-            for (var word of finalWordsToAdd) // go up to last word of set
-            this.selectedWord = word; // select last word
-            this.formatMagnitudePlot("similarity");
-            this.highlightVectorAxis(true);
-        }
-        else {
+        // if word added/removed, clear selection and similarity redlines (switch to default mode)
+        if (wordModified) {
             this.selectedWord = "";
             this.formatMagnitudePlot("default");
             this.highlightVectorAxis(false);
+            this.updateSimilarityLines(true, false);
+        } else {
+            // keep current status unchanged when NO VALID word added/removed
+            if (this.selectedWord) {
+                this.formatMagnitudePlot("similarity");
+                this.highlightVectorAxis(true);
+            } else {
+                this.formatMagnitudePlot("default");
+                this.highlightVectorAxis(false);
+            }
         }
 
         // generate message as per changes to words

--- a/wordembeddingdemo.js
+++ b/wordembeddingdemo.js
@@ -621,14 +621,20 @@ class Demo {
             }
         });
 
-        // if word added/removed, clear selection and similarity redlines (switch to default mode)
+        // update selection on add/remove without entering similarity mode
         if (wordModified) {
-            this.selectedWord = "";
+            if (addedWords.length > 0) {
+                // keep red-highlighted feedback in scatter by selecting the latest added word
+                this.selectedWord = addedWords[addedWords.length - 1];
+            } else if (removedWords.length > 0) {
+                // remove-only, clears current active word selection
+                this.selectedWord = "";
+            }
             this.formatMagnitudePlot("default");
             this.highlightVectorAxis(false);
             this.updateSimilarityLines(true, false);
         } else {
-            // keep current status unchanged when NO VALID word added/removed
+            // if there is NO VALID add/remove, keep current status quo
             if (this.selectedWord) {
                 this.formatMagnitudePlot("similarity");
                 this.highlightVectorAxis(true);


### PR DESCRIPTION
Switch back to the defualt mode (no word selected) after a word is added or removed.
If the input word is not valid, it will remain unchanged as it is.

### Before entering a new word while a word is selected
<img width="1673" height="1136" alt="Before changing wordlist" src="https://github.com/user-attachments/assets/3ecc2a9f-bdd6-4a7a-b455-a0dcb761047e" />

### After entering a new word
<img width="1673" height="1136" alt="After changing wordlist" src="https://github.com/user-attachments/assets/1a60b777-06fb-4ffe-afba-e4b1911f6d8e" />