### PR TITLE
Fix blank-line handling in semantic dimensions subpanel word lists

### DIFF
--- a/wordembeddingdemo.js
+++ b/wordembeddingdemo.js
@@ -771,7 +771,8 @@ class Demo {
                 // split words across new lines
                 // convert to lowercase (#39)
                 featureWordsPairsInput[i][j] =
-                    document.querySelector(`.user-feature-words.${selectedNames[i]}.set${j}`).value.toLowerCase().split('\n');
+                    // filter out empty strings and convert to lowercase
+                    document.querySelector(`.user-feature-words.${selectedNames[i]}.set${j}`).value.split(/\r?\n/).map((word) => word.trim().toLowerCase()).filter(Boolean);
             }
         }
 

--- a/wordembeddingdemo.js
+++ b/wordembeddingdemo.js
@@ -770,9 +770,14 @@ class Demo {
             for (let j=0; j<2; j++) {
                 // split words across new lines
                 // convert to lowercase (#39)
-                featureWordsPairsInput[i][j] =
-                    // filter out empty strings and convert to lowercase
-                    document.querySelector(`.user-feature-words.${selectedNames[i]}.set${j}`).value.split(/\r?\n/).map((word) => word.trim().toLowerCase()).filter(Boolean);
+                const rawInput = document
+                    .querySelector(`.user-feature-words.${selectedNames[i]}.set${j}`)
+                    .value
+                    // remove trailing blank lines (kept the blank lines in the middle to trigger '"" not found' error message)
+                    .replace(/(?:\r?\n[^\S\r\n]*)+$/, "");
+                featureWordsPairsInput[i][j] = rawInput
+                    .split(/\r?\n/)
+                    .map((word) => word.trim().toLowerCase());
             }
         }
 


### PR DESCRIPTION
Before, extra newlines or spaces cause `""not found` errors and change the list length, which could confuse users.
<img width="579" height="259" alt="Empty String_before fix1" src="https://github.com/user-attachments/assets/9608a13c-77a1-4ebb-8571-ce31b7dc5d48" />
<img width="575" height="265" alt="Empty String_before fix2" src="https://github.com/user-attachments/assets/1bf98dd6-7eda-4238-b457-b454e9117bb1" />

Now, blank lines (including spaces) are trimmed before processing the list.
<img width="578" height="255" alt="Empty String_after fix" src="https://github.com/user-attachments/assets/5ff07d3d-2db3-4e64-ace3-b039e4a6e709" />

